### PR TITLE
add ability to change language for open weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ return [
             'open_weather_map_key' => env('OPEN_WEATHER_MAP_KEY'),
             'open_weather_map_city' => 'Antwerp',
             'units' => 'metric', // 'metric' or 'imperial' (metric is default)
+            'locale' => 'en_US',
         ],
     ],
 ];
@@ -55,7 +56,7 @@ In your dashboard view you use the `livewire:weather-forecast-tile` component.
 
 ```html
 <x-dashboard>
-    <livewire:weather-forecast-tile position="a1" />
+  <livewire:weather-forecast-tile position="a1" />
 </x-dashboard>
 ```
 

--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -1,5 +1,5 @@
 <x-dashboard-tile :position="$position">
-    <div 
+    <div
         wire:poll.{{ $refreshIntervalInSeconds }}s
         class="grid gap-2 justify-items-center h-full text-center"
     >

--- a/src/FetchDataFromApiCommand.php
+++ b/src/FetchDataFromApiCommand.php
@@ -17,7 +17,8 @@ class FetchDataFromApiCommand extends Command
         $data = $weatherForecast->getWeatherForecast(
             config('dashboard.tiles.weather_forecast.open_weather_map_key'),
             config('dashboard.tiles.weather_forecast.open_weather_map_city'),
-            config('dashboard.tiles.weather_forecast.units') ?? 'metric'
+            config('dashboard.tiles.weather_forecast.units') ?? 'metric',
+            config('dashboard.tiles.weather_forecast.locale') ?? 'en_US'
         );
 
         WeatherForecastStore::make()->setData($data);

--- a/src/WeatherForecast.php
+++ b/src/WeatherForecast.php
@@ -4,29 +4,32 @@ namespace Solitweb\WeatherForecastTile;
 
 use Illuminate\Support\Facades\Http;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 class WeatherForecast
 {
-    public static function getWeatherForecast(string $key, string $city, string $units): array
+    public static function getWeatherForecast(string $key, string $city, string $units, string $locale): array
     {
-        $url = "https://api.openweathermap.org/data/2.5/forecast?q={$city}&appid={$key}&units={$units}";
+        $lang = Str::of($locale)->substr(0, 2);
+        $url = "https://api.openweathermap.org/data/2.5/forecast?q={$city}&appid={$key}&units={$units}&lang={$lang}";
 
         $response = Http::get($url)->json();
 
-        if (!array_key_exists('list', $response)) {
+        if (! array_key_exists('list', $response)) {
             return [];
         }
 
         return collect($response['list'])
-            ->map(function (array $forecast, int $key) {
-                $timestamp = Carbon::parse($forecast['dt_txt']);
+            ->map(function (array $forecast, int $key) use ($locale) {
+                $timestamp = Carbon::parse($forecast['dt_txt'])->locale($locale);
 
-                if (($key === 0) || (!$timestamp->isToday() && $timestamp->isMidday())) {
+                if (($key === 0) || (! $timestamp->isToday() && $timestamp->isMidday())) {
                     return [
-                        'dayName' => $timestamp->dayName,
-                        'temp' => (int) $forecast['main']['temp'],
-                        'wind' => (array) $forecast['wind'],
-                        'weather' => (array) $forecast['weather'][0],
+                        'dayName'  => $timestamp->dayName,
+                        'datetime' => $timestamp,
+                        'temp'     => (int) $forecast['main']['temp'],
+                        'wind'     => (array) $forecast['wind'],
+                        'weather'  => (array) $forecast['weather'][0],
                     ];
                 }
             })


### PR DESCRIPTION
Hey there!

I really enjoy this tile and it's very flexible and well made! Thanks for making this tile!

I wanted to suggest adding localisation possibilities by adding the ability to request a language specific request from the Open Weather Api.
For reference see: https://openweathermap.org/current#multi

Also upon saving the data received I also added a datetime so that this could be used and parsed freely with e.g. Carbon.

This change allows me to set my locale to for example 'nl_NL' and result in the below tile:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/13934159/177626037-427e7817-d231-477d-9cfe-ea761e4bafb6.png">

If you would like to see any further edits, I'd love to hear about them.

Cheers,
Roël